### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The original sets of routines came directly out of the earliest projects where I
 
 Latest: 15/06/2015
 	Updated to ensure nothing spills into global namespace by default
-	Updated to use a consistant function signature style
+	Updated to use a consistent function signature style
 
 Current: Works against LUAJIT git HEAD as of 15/06/2015
 


### PR DESCRIPTION
@Wiladams, I've corrected a typographical error in the documentation of the [LAPHLibs](https://github.com/Wiladams/LAPHLibs) project. Specifically, I've changed consistant to consistent. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
